### PR TITLE
[#124 and #222] Group Page view members & Group Image responsiveness features

### DIFF
--- a/frontend/src/components/Network/GroupNetwork.js
+++ b/frontend/src/components/Network/GroupNetwork.js
@@ -110,7 +110,7 @@ function GroupNetwork() {
                       <Card className="card">
                         <Row>
                           <Col md={2} sm={12} className="text-center">
-                            <img src={groupInfos.group_img_url ? groupInfos.group_img_url : grouplogo} style={{ maxHeight: '150px', minHeight: '150px'}} className="img-fluid my-3" alt="template_group_pic" />
+                            <img src={groupInfos.group_img_url ? groupInfos.group_img_url : grouplogo} style={{ maxHeight: '150px', minWidth: '100%', width: '150px', height: '150px', objectFit: 'contain', }} className="img-fluid my-3" alt="template_group_pic" />
                           </Col>
                           <Col md={8} sm={12}>
                             <h3> {groupInfos.group_name}</h3>
@@ -141,7 +141,7 @@ function GroupNetwork() {
                   <Card className="card">
                     <Row>
                       <Col md={2} sm={12} className="text-center">
-                      <img src={groupInfos.group_img_url ? groupInfos.group_img_url : grouplogo} style={{ maxHeight: '150px', minHeight: '150px' }} alt="template_group_pic" className="img-fluid my-3" />
+                      <img src={groupInfos.group_img_url ? groupInfos.group_img_url : grouplogo} style={{ maxHeight: '150px', minWidth: '100%', width: '150px', height: '150px', objectFit: 'contain', }} className="img-fluid my-3" alt="template_group_pic" />
                       </Col>
                       <Col md={8}>
                         <h3> {groupInfos.group_name}</h3>

--- a/frontend/src/components/Network/GroupNetwork.js
+++ b/frontend/src/components/Network/GroupNetwork.js
@@ -109,16 +109,16 @@ function GroupNetwork() {
                     <div className="post-content" key={groupInfos.id}> 
                       <Card className="card">
                         <Row>
-                          <Col md={1} className="text-center">
-                            <img src={groupInfos.group_img_url ? groupInfos.group_img_url : grouplogo} style={{ maxHeight: '150px' }} alt="template_group_pic" className="group_pic_center" />
+                          <Col md={2} sm={12} className="text-center">
+                            <img src={groupInfos.group_img_url ? groupInfos.group_img_url : grouplogo} style={{ maxHeight: '150px', minHeight: '150px'}} className="img-fluid my-3" alt="template_group_pic" />
                           </Col>
-                          <Col md={9} >
+                          <Col md={8} sm={12}>
                             <h3> {groupInfos.group_name}</h3>
                             <h5> {groupInfos.memberUIDs.length} {groupInfos.memberUIDs.length === 1 ? "member" : "members"}</h5>
                         <hr></hr>
                         <p> {groupInfos.description}</p>
                           </Col>
-                          <Col className="center-col" md={2}>
+                          <Col className="center-col" md={2} sm={12}>
                             <Link to={`/group/${groupInfos.id}`}>
                               <Button className="create_Group_Button" >View Group</Button>
                             </Link>
@@ -140,16 +140,16 @@ function GroupNetwork() {
                 <div className="post-content" key={groupInfos.id}> 
                   <Card className="card">
                     <Row>
-                      <Col md={1}>
-                      <img src={groupInfos.group_img_url ? groupInfos.group_img_url : grouplogo} style={{ maxHeight: '150px' }} alt="template_group_pic" className="group_pic_center" />
+                      <Col md={2} sm={12} className="text-center">
+                      <img src={groupInfos.group_img_url ? groupInfos.group_img_url : grouplogo} style={{ maxHeight: '150px', minHeight: '150px' }} alt="template_group_pic" className="img-fluid my-3" />
                       </Col>
-                      <Col md={9}>
+                      <Col md={8}>
                         <h3> {groupInfos.group_name}</h3>
                         <h5> {groupInfos.memberUIDs.length} {groupInfos.memberUIDs.length === 1 ? "member" : "members"}</h5>
                         <hr />
                         <p> {groupInfos.description}</p>
                       </Col>
-                      <Col className="center-col" md={2}>
+                      <Col className="center-col" md={2} sm={12}>
                         <Button className="create_Group_Button" onClick={() => handleRequest(index)}>
                         Join Group
                         </Button>

--- a/frontend/src/components/Network/GroupPage.js
+++ b/frontend/src/components/Network/GroupPage.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
 //Firebase Imports
-import { doc, getDoc, updateDoc } from "firebase/firestore";
+import { doc, getDoc, getDocs, updateDoc, where, query, collection } from "firebase/firestore";
 import { db, auth } from "../../firebase";
 
 //Styling Imports
@@ -24,10 +24,10 @@ import Feed from "../UserFeedPage/Feed"
 * @return { Object } The page as a React component with the information of the group.
 */
 function GroupPage() {
-
   const navigate = useNavigate();
   const { id } = useParams();
   const [group, setGroup] = useState(null);
+  const [memberNames, setMemberNames] = useState([]);
 
   // Here we set the group variable with the information matching the group ID.
   useEffect(() => {
@@ -38,9 +38,23 @@ function GroupPage() {
       // Set the group to the groupDoc.
       if (groupDoc.exists()) {
         setGroup(groupDoc.data());
+
+       // Fetch member names from users_information collection.
+       const membersRef = collection(db, "users_information");
+       const membersQuery = query(membersRef, where("id", "in", groupDoc.data().memberUIDs));
+       const memberDocs = await getDocs(membersQuery);
+       const memberNamesArray = memberDocs.docs.map((doc) => {
+        const firstName = doc.data().firstName;
+        const lastName = doc.data().lastName;
+        return `${firstName || "Unnamed"} ${lastName || ""}`.trim();
+      });
+
+       setMemberNames(memberNamesArray);
+
       } else {
         console.log("No such group exists.");
       }
+
     };
 
     fetchGroup();
@@ -55,28 +69,30 @@ function GroupPage() {
   const leaveGroup = async () => {
     const groupRef = doc(db, "groups", id);
     const groupDoc = await getDoc(groupRef);
-  
-    const updatedGroup = { 
+
+    const updatedGroup = {
       ...groupDoc.data(),
-      memberUIDs: groupDoc.data().memberUIDs.filter(uid => uid !== auth.currentUser.uid)
+      memberUIDs: groupDoc
+        .data()
+        .memberUIDs.filter((uid) => uid !== auth.currentUser.uid),
     };
-  
+
     await updateDoc(groupRef, updatedGroup);
 
-    navigate('/GroupNetwork');
-  }
+    navigate("/GroupNetwork");
+  };
 
   //Here we display the information relevant to the group
   return (
     <div className="contain">
       <Row className="gap-5">
-
         {/* Left Sidebar of the group page, where all group information is found*/}
         <Col className="col1" xs={12} md={{ span: 3, offset: 1 }}>
-
           <Card className="profilecard">
-            <img src={group.group_img_url}/>
-            <h1><span style={{ color: "#27746A" }}> {group.group_name} </span></h1>
+            <img src={group.group_img_url} style={{ maxHeight: "500px" }} />
+            <h1>
+              <span style={{ color: "#27746A" }}> {group.group_name} </span>
+            </h1>
             <h5>
               {group.memberUIDs.length}{" "}
               {group.memberUIDs.length === 1 ? "member" : "members"}
@@ -84,22 +100,38 @@ function GroupPage() {
             <h4>{group.industry}</h4>
             <h5>{group.location}</h5>
             <p>{group.description}</p>
-            <Button variant="primary" size="lg" block className="w-100" style={{backgroundColor:'#27746a'}} onClick={leaveGroup}>Leave Group</Button>
+            <Button
+              variant="primary"
+              size="lg"
+              block
+              className="w-100"
+              style={{ backgroundColor: "#27746a" }}
+              onClick={leaveGroup}
+            >
+              Leave Group
+            </Button>
           </Card>
 
-          <Card className="profilecard">
+          <Card className="profilecard" style={{minHeight: `${Math.max(memberNames.length * 40, 100)}px`}}>
             <h2> Active Members </h2>
-            <hr></hr>
-            <h4> WIP </h4>
+            <hr />
+            {group.memberUIDs.length > 0 ? (
+              <ul class="list-group">
+                {memberNames.map((name, index) => (
+                  <li key={index} class="list-group-item" > {name} </li>
+                ))}
+              </ul>
+            ) : (
+              <p>No active members</p>
+            )}
           </Card>
 
         </Col>
 
         {/* Main section where the group feed will be mapped*/}
-        <Col style={{margin:'0% -15% 0% -20%'}}>
-            <Feed/>
+        <Col style={{ margin: "0% -15% 0% -20%" }}>
+          <Feed />
         </Col>
-
       </Row>
     </div>
   );

--- a/frontend/src/components/Network/GroupPage.js
+++ b/frontend/src/components/Network/GroupPage.js
@@ -1,9 +1,17 @@
 //React Imports
 import { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 
 //Firebase Imports
-import { doc, getDoc, getDocs, updateDoc, where, query, collection } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  getDocs,
+  updateDoc,
+  where,
+  query,
+  collection,
+} from "firebase/firestore";
 import { db, auth } from "../../firebase";
 
 //Styling Imports
@@ -16,13 +24,13 @@ import Card from "react-bootstrap/Card";
 import Button from "react-bootstrap/Button";
 
 //Feed Import
-import Feed from "../UserFeedPage/Feed"
+import Feed from "../UserFeedPage/Feed";
 
 /**
-* The GroupPage displays a view of a group. It is used to select the target group, retrieve its information from the Firestore, and display it.
-*
-* @return { Object } The page as a React component with the information of the group.
-*/
+ * The GroupPage displays a view of a group. It is used to select the target group, retrieve its information from the Firestore, and display it.
+ *
+ * @return { Object } The page as a React component with the information of the group.
+ */
 function GroupPage() {
   const navigate = useNavigate();
   const { id } = useParams();
@@ -39,22 +47,25 @@ function GroupPage() {
       if (groupDoc.exists()) {
         setGroup(groupDoc.data());
 
-       // Fetch member names from users_information collection.
-       const membersRef = collection(db, "users_information");
-       const membersQuery = query(membersRef, where("id", "in", groupDoc.data().memberUIDs));
-       const memberDocs = await getDocs(membersQuery);
-       const memberNamesArray = memberDocs.docs.map((doc) => {
-        const firstName = doc.data().firstName;
-        const lastName = doc.data().lastName;
-        return `${firstName || "Unnamed"} ${lastName || ""}`.trim();
-      });
+        // Fetch member names from users_information collection.
+        const membersRef = collection(db, "users_information");
+        const membersQuery = query(
+          membersRef,
+          where("id", "in", groupDoc.data().memberUIDs)
+        );
+        const memberDocs = await getDocs(membersQuery);
+        const memberNamesArray = memberDocs.docs.map((doc) => {
+          const firstName = doc.data().firstName;
+          const lastName = doc.data().lastName;
+          const fullName = `${firstName || "Unnamed"} ${lastName || ""}`.trim();
+          const profileLink = `/profile/${doc.id}`;
+          return { fullName, profileLink };
+        });
 
-       setMemberNames(memberNamesArray);
-
+        setMemberNames(memberNamesArray);
       } else {
         console.log("No such group exists.");
       }
-
     };
 
     fetchGroup();
@@ -112,23 +123,28 @@ function GroupPage() {
             </Button>
           </Card>
 
-          <Card className="profilecard" style={{minHeight: `${Math.max(memberNames.length * 40, 100)}px`}}>
+          {/* Section where all the users who joined the group are displayed.*/}
+          <Card
+            className="profilecard"
+            style={{ minHeight: `${Math.max(memberNames.length * 40, 100)}px` }}
+          >
             <h2> Active Members </h2>
             <hr />
             {group.memberUIDs.length > 0 ? (
-              <ul class="list-group">
-                {memberNames.map((name, index) => (
-                  <li key={index} class="list-group-item" > {name} </li>
+              <ul className="list-group">
+                {memberNames.map(({ fullName, profileLink }, index) => (
+                  <li key={index} className="list-group-item">
+                    <Link to={profileLink}>{fullName}</Link>
+                  </li>
                 ))}
               </ul>
             ) : (
               <p>No active members</p>
             )}
           </Card>
-
         </Col>
 
-        {/* Main section where the group feed will be mapped*/}
+        {/* Main section where the group feed will be mapped */}
         <Col style={{ margin: "0% -15% 0% -20%" }}>
           <Feed />
         </Col>

--- a/frontend/src/components/Network/GroupPage.js
+++ b/frontend/src/components/Network/GroupPage.js
@@ -22,6 +22,7 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Card from "react-bootstrap/Card";
 import Button from "react-bootstrap/Button";
+import grouplogo from ".././../images/group.png";
 
 //Feed Import
 import Feed from "../UserFeedPage/Feed";
@@ -100,7 +101,7 @@ function GroupPage() {
         {/* Left Sidebar of the group page, where all group information is found*/}
         <Col className="col1" xs={12} md={{ span: 3, offset: 1 }}>
           <Card className="profilecard">
-            <img src={group.group_img_url} style={{ maxHeight: "500px" }} />
+            <img src={group.group_img_url ? group.group_img_url : grouplogo} style={{ maxHeight: "500px" }} />
             <h1>
               <span style={{ color: "#27746A" }}> {group.group_name} </span>
             </h1>


### PR DESCRIPTION
Adds the functionality to view/contact/connect with common users who joined the same group, and fixes a known styling bug.

More specifically, this PR:

+ Allows users view the members/users of a joined group.
+ Allows users click on the users to see their profile, and connect with them.
+ Fixes the overflowing group image on the GroupNetwork page. #222 

Files/

[Modified] GroupPage.js
[Modified] GroupNetwork.js

TODO:

- [ ] Possibly add profile icons next to the users in the Members section.